### PR TITLE
InterleavedSemiIterator: Implement pre- and post-operator--

### DIFF
--- a/dfg/iter/interleavedIterator.hpp
+++ b/dfg/iter/interleavedIterator.hpp
@@ -46,6 +46,19 @@ public:
 		return iter;
 	}
 
+	DFG_CLASS_NAME(InterleavedSemiIterator)& operator--()
+	{
+      m_pData -= m_nChannelCount;
+      return *this;
+	}
+
+	DFG_CLASS_NAME(InterleavedSemiIterator) operator--(int) const
+	{
+      auto iter = *this;
+      --*this;
+      return iter;
+	}
+
 	const Data_T& operator*() const
 	{
 		return *m_pData;


### PR DESCRIPTION
Missing operator-- led to the following compilation error:

In file included from /usr/include/c++/9.1.0/bits/stl_algobase.h:66,
                 from /usr/include/c++/9.1.0/bits/char_traits.h:39,
                 from /usr/include/c++/9.1.0/ios:40,
                 from /usr/include/c++/9.1.0/ostream:38,
                 from /usr/include/c++/9.1.0/iostream:39,
                 from ./stdafx.h:13,
                 from dfgTestCont.cpp:1:
/usr/include/c++/9.1.0/bits/stl_iterator_base_funcs.h: In instantiation of ‘void std::__advance(_RandomAccessIterator&, _Distance, std::random_access_iterator_tag) [with _RandomAccessIterator = dfg::iter::InterleavedSemiIterator<const double>; _Distance = long int]’:
/usr/include/c++/9.1.0/bits/stl_iterator_base_funcs.h:206:21:   required from ‘void std::advance(_InputIterator&, _Distance) [with _InputIterator = dfg::iter::InterleavedSemiIterator<const double>; _Distance = long int]’
/usr/include/c++/9.1.0/bits/stl_algobase.h:978:16:   required from ‘_ForwardIterator std::__lower_bound(_ForwardIterator, _ForwardIterator, const _Tp&, _Compare) [with _ForwardIterator = dfg::iter::InterleavedSemiIterator<const double>; _Tp = double; _Compare = __gnu_cxx::__ops::_Iter_less_val]’
/usr/include/c++/9.1.0/bits/stl_algobase.h:1013:32:   required from ‘_ForwardIterator std::lower_bound(_ForwardIterator, _ForwardIterator, const _Tp&) [with _ForwardIterator = dfg::iter::InterleavedSemiIterator<const double>; _Tp = double]’
../dfg/cont/interleavedXsortedTwoChannelWrapper.hpp:41:37:   required from ‘Data_T dfg::cont::InterleavedXsortedTwoChannelWrapper<Data_T>::operator()(const Data_T&) const [with Data_T = const double]’
dfgTestCont.cpp:1219:5:   required from here
/usr/include/c++/9.1.0/bits/stl_iterator_base_funcs.h:183:2: error: no match for ‘operator--’ (operand type is ‘dfg::iter::InterleavedSemiIterator<const double>’)
  183 |  --__i;
      |  ^~~~~