### PR TITLE
Missing includes

### DIFF
--- a/dfg/qt/containerUtils.hpp
+++ b/dfg/qt/containerUtils.hpp
@@ -9,6 +9,7 @@ DFG_BEGIN_INCLUDE_QT_HEADERS
 #include <QPointer>
 DFG_END_INCLUDE_QT_HEADERS
 
+#include <memory>
 
 DFG_ROOT_NS_BEGIN{ DFG_SUB_NS(qt)
 {

--- a/dfgExamples/dfgQtTableEditor/main.cpp
+++ b/dfgExamples/dfgQtTableEditor/main.cpp
@@ -23,11 +23,9 @@ DFG_END_INCLUDE_QT_HEADERS
 #include <dfg/debug/structuredExceptionHandling.h>
 #include <dfg/qt/CsvTableView.hpp>
 
-#ifdef _WIN32
-    DFG_BEGIN_INCLUDE_WITH_DISABLED_WARNINGS
-        #include <dfg/str/fmtlib/format.cc>
-    DFG_END_INCLUDE_WITH_DISABLED_WARNINGS
-#endif // _WIN32
+DFG_BEGIN_INCLUDE_WITH_DISABLED_WARNINGS
+    #include <dfg/str/fmtlib/format.cc>
+DFG_END_INCLUDE_WITH_DISABLED_WARNINGS
 
 static QWidget* gpMainWindow = nullptr;
 


### PR DESCRIPTION
Some missing includes found by trying to compile dfgQtTableEditor on Linux with GCC 9.2.